### PR TITLE
Refactored for stats schema updates

### DIFF
--- a/htc-api/api/htc_api.py
+++ b/htc-api/api/htc_api.py
@@ -122,16 +122,6 @@ def documentation():
     return auto.html(title='MA High Tech Counsel API Documentation')
 
 
-
-#Get Disease ID of a given disease from Disease table
-def getDiseaseID(name):
-    con = get_db_con()
-    sql = "SELECT diseasefp FROM synth_ma.synth_disease " \
-        "WHERE stat_name = '" + str(name) + "'"
-    data = getData(con, sql)
-    return (json.loads(data))[0]['diseasefp']
-
-
 #All Counties
 #
 #Request geojson of all counties
@@ -140,7 +130,7 @@ def getDiseaseID(name):
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_counties_all():
     """Counties in GeoJSON"""
-    log.debug("entering get_counties_all() IP=%s" % get_ip());
+    log.debug("entering get_counties_all() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate as chr_hs_grad, chr.college as chr_college, chr.unemployed as chr_unemployed, chr.diabetes_rate as chr_diabetes, " \
@@ -151,7 +141,7 @@ def get_counties_all():
       "JOIN tiger_cb14_500k.county g ON g.statefp = '25' AND g.countyfp = s.ct_fips " \
       "JOIN county_health.chr ON chr.statefp = '25' AND chr.release_year = 2016 AND chr.countyfp = s.ct_fips"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_counties_all()");
+    log.debug("leaving get_counties_all()")
     return data
 
 #Request geojson of all counties (synthetic data)
@@ -160,16 +150,16 @@ def get_counties_all():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_synth_counties_all():
     """Counties in GeoJSON synthetic"""
-    log.debug("entering get_synth_counties_all() IP=%s" % get_ip());
+    log.debug("entering get_synth_counties_all() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes, " \
-        "ST_AsGeoJSON(g.the_geom) AS geometry " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN tiger_cb14_500k.county g ON g.statefp = '25' AND g.countyfp = s.ct_fips " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips"
+        "ST_AsGeoJSON(s.ct_poly) AS geometry, " \
+        "d.rate as pct_diabetes " \
+        "FROM synth_ma.synth_county_pop_stats s " \
+        "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+        "WHERE d.disease_name = 'diabetes'"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_synth_counties_all()");
+    log.debug("leaving get_synth_counties_all()")
     return data
 
 #Request list of all counties
@@ -178,12 +168,12 @@ def get_synth_counties_all():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_counties():
     """Counties list in JSON"""
-    log.debug("entering get_counties() IP=%s" % get_ip());
+    log.debug("entering get_counties() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT ct_name, ct_fips " \
       "FROM synth_ma.county_stats"
     data = getData(con, sql)
-    log.debug("leaving get_counties()");
+    log.debug("leaving get_counties()")
     return data
 
 #Request list of all counties (synthetic)
@@ -192,13 +182,26 @@ def get_counties():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_synth_counties():
     """Counties list in JSON synthetic"""
-    log.debug("entering get_synth_counties() IP=%s" % get_ip());
+    log.debug("entering get_synth_counties() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT ct_name, ct_fips " \
-      "FROM synth_ma.synth_county_stats"
+      "FROM synth_ma.synth_county_pop_stats"
     data = getData(con, sql)
-    log.debug("leaving get_synth_counties()");
+    log.debug("leaving get_synth_counties()")
     return data
+
+#Request list of disease names that we have statistics for (synthetic)
+@app.route('/htc/api/v1/synth/diseases/list', methods=['GET'])
+@auto.doc()
+@cache.cached(timeout=300)
+def get_synth_diseases():
+  """Disease list in JSON synthetic"""
+  log.debug("entering get_synth_diseases() IP=%s" %get_ip())
+  con = get_db_con()
+  sql = "SELECT DISTINCT disease_name FROM synth_ma.synth_county_disease_stats"
+  data = getData(con, sql)
+  log.debug("leaving get_synth_diseases()")
+  return data
 
 #Request geojson of only the geometry of all counties
 @app.route('/htc/api/v1/counties/geoms', methods=['GET'])
@@ -206,12 +209,12 @@ def get_synth_counties():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_counties_geom():
     """Counties in GeoJSON, geometry only"""
-    log.debug("entering get_counties_geom() IP=%s" % get_ip());
+    log.debug("entering get_counties_geom() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT countyfp AS ct_fips, ST_AsGeoJSON(the_geom) AS geometry " \
       "FROM tiger_cb14_500k.county WHERE statefp='25'"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_counties_geom()");
+    log.debug("leaving get_counties_geom()")
     return data
 
 #Request only the statistics of all counties
@@ -220,7 +223,7 @@ def get_counties_geom():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_counties_stats():
     """Counties in JSON, statistics only"""
-    log.debug("entering get_counties_stats() IP=%s" % get_ip());
+    log.debug("entering get_counties_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate / 100 as chr_hs_grad, chr.college / 100 as chr_college, chr.unemployed / 100 as chr_unemployed, chr.diabetes_rate / 100 as chr_diabetes, " \
@@ -229,7 +232,7 @@ def get_counties_stats():
       "JOIN synth_ma.ma_opioid_county opioid ON opioid.countyfp = s.ct_fips AND opioid.year = '2015' " \
       "JOIN county_health.chr ON chr.statefp = '25' AND chr.release_year = 2016 AND chr.countyfp = s.ct_fips"
     data = getData(con, sql)
-    log.debug("leaving get_counties_stats()");
+    log.debug("leaving get_counties_stats()")
     return data
 
 #Request only the statistics of all counties (synthetic)
@@ -238,14 +241,15 @@ def get_counties_stats():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_synth_counties_stats():
     """Counties in JSON, statistics only synthetic"""
-    log.debug("entering get_synth_counties_stats() IP=%s" % get_ip());
+    log.debug("entering get_synth_counties_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips"
+      "d.rate as pct_diabetes " \
+      "FROM synth_ma.synth_county_pop_stats s " \
+      "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+      "WHERE d.disease_name = 'diabetes'"
     data = getData(con, sql)
-    log.debug("leaving get_synth_counties_stats()");
+    log.debug("leaving get_synth_counties_stats()")
     return data
 
 #Single County
@@ -256,7 +260,7 @@ def get_synth_counties_stats():
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_name(ct_name):
     """County in GeoJSON, by name"""
-    log.debug("entering get_county_by_name() IP=%s" % get_ip());
+    log.debug("entering get_county_by_name() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate as chr_hs_grad, chr.college as chr_college, chr.unemployed as chr_unemployed, chr.diabetes_rate as chr_diabetes, " \
@@ -269,7 +273,7 @@ def get_county_by_name(ct_name):
       "WHERE ct_name=%s"
     sql_params = (ct_name.title(),)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_name()");
+    log.debug("leaving get_county_by_name()")
     return data
 
 #Request geojson of single county by name (synthetic)
@@ -278,18 +282,17 @@ def get_county_by_name(ct_name):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_synth_county_by_name(ct_name):
     """County in GeoJSON, by name synthetic"""
-    log.debug("entering get_synth_county_by_name() IP=%s" % get_ip());
+    log.debug("entering get_synth_county_by_name() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes, " \
-        "ST_AsGeoJSON(s.ct_poly) AS geometry " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN tiger_cb14_500k.county g ON g.statefp = '25' AND g.countyfp = s.ct_fips " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips " \
-      "WHERE ct_name=%s"
+        "ST_AsGeoJSON(s.ct_poly) AS geometry, " \
+        "d.rate AS pct_diabetes " \
+      "FROM synth_ma.synth_county_pop_stats s " \
+      "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+      "WHERE s.ct_name = %s AND d.disease_name = 'diabetes'"
     sql_params = (ct_name.title(),)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_synth_county_by_name()");
+    log.debug("leaving get_synth_county_by_name()")
     return data
 
 #Request geojson of only the geometry of a single county by name
@@ -298,14 +301,14 @@ def get_synth_county_by_name(ct_name):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_name_geom(ct_name):
     """County in GeoJSON, by name, geometry only"""
-    log.debug("entering get_county_by_name_geom() IP=%s" % get_ip());
+    log.debug("entering get_county_by_name_geom() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT countyfp AS ct_fips, ST_AsGeoJSON(the_geom) AS geometry " \
       "FROM tiger_cb14_500k.county " \
       "WHERE statefp='25' AND name=%s"
     sql_params = (ct_name.title(),)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_name_geom()");
+    log.debug("leaving get_county_by_name_geom()")
     return data
 
 #Request only the statistics of a single county by name
@@ -314,7 +317,7 @@ def get_county_by_name_geom(ct_name):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_name_stats(ct_name):
     """County in JSON, by name, statistics only"""
-    log.debug("entering get_county_by_name_stats() IP=%s" % get_ip());
+    log.debug("entering get_county_by_name_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate as chr_hs_grad, chr.college as chr_college, chr.unemployed as chr_unemployed, chr.diabetes as chr_diabetes, " \
@@ -325,7 +328,7 @@ def get_county_by_name_stats(ct_name):
       "WHERE s.ct_name=%s"
     sql_params = (ct_name.title(),)
     data = getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_name_stats()");
+    log.debug("leaving get_county_by_name_stats()")
     return data
 
 #Request only the statistics of a single county by name (synthetic)
@@ -334,16 +337,16 @@ def get_county_by_name_stats(ct_name):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_synth_county_by_name_stats(ct_name):
     """County in JSON, by name, statistics only (synthetic)"""
-    log.debug("entering get_synth_county_by_name_stats() IP=%s" % get_ip());
+    log.debug("entering get_synth_county_by_name_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips " \
-      "WHERE s.ct_name=%s"
+      "d.rate as pct_diabetes " \
+      "FROM synth_ma.synth_county_pop_stats s " \
+      "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+      "WHERE s.ct_name = %s AND d.disease_name = 'diabetes'"
     sql_params = (ct_name.title(),)
     data = getData(con, sql, sql_params)
-    log.debug("leaving get_synth_county_by_name_stats()");
+    log.debug("leaving get_synth_county_by_name_stats()")
     return data
 
 #Request single county by county id
@@ -352,7 +355,7 @@ def get_synth_county_by_name_stats(ct_name):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_id(ct_fips):
     """County in GeoJSON, by id"""
-    log.debug("entering get_county_by_id() IP=%s" % get_ip());
+    log.debug("entering get_county_by_id() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate as chr_hs_grad, chr.college as chr_college, chr.unemployed as chr_unemployed, chr.diabetes_rate as chr_diabetes, " \
@@ -365,7 +368,7 @@ def get_county_by_id(ct_fips):
       "WHERE ct_fips=%s"
     sql_params = (ct_fips,)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_id()");
+    log.debug("leaving get_county_by_id()")
     return data
 
 #Request single county by county id (synthetic)
@@ -374,18 +377,17 @@ def get_county_by_id(ct_fips):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_synth_county_by_id(ct_fips):
     """County in GeoJSON, by id (synthetic)"""
-    log.debug("entering get_synth_county_by_id() IP=%s" % get_ip());
+    log.debug("entering get_synth_county_by_id() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes, " \
-        "ST_AsGeoJSON(the_geom) AS geometry " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN tiger_cb14_500k.county g ON g.statefp = '25' AND g.countyfp = s.ct_fips " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips " \
-      "WHERE ct_fips=%s"
+        "d.rate as pct_diabetes, " \
+        "ST_AsGeoJSON(s.ct_poly) AS geometry " \
+      "FROM synth_ma.synth_county_pop_stats s " \
+      "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+      "WHERE s.ct_fips = %s AND d.disease_name = 'diabetes'"
     sql_params = (ct_fips,)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_synth_county_by_id()");
+    log.debug("leaving get_synth_county_by_id()")
     return data
 
 #Request geojson of only geometry of a single county by county id
@@ -394,14 +396,14 @@ def get_synth_county_by_id(ct_fips):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_id_geom(ct_fips):
     """County in GeoJSON, by id, geometry only"""
-    log.debug("entering get_county_by_id_geom() IP=%s" % get_ip());
+    log.debug("entering get_county_by_id_geom() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT countyfp AS ct_fips, ST_AsGeoJSON(the_geom) AS geometry " \
       "FROM tiger_cb14_500k.county " \
       "WHERE statefp='25' AND countyfp=%s"
     sql_params = (ct_fips,)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_id_geom()");
+    log.debug("leaving get_county_by_id_geom()")
     return data
 
 #Request only the statistics of a single county by county id
@@ -410,7 +412,7 @@ def get_county_by_id_geom(ct_fips):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_county_by_id_stats(ct_fips):
     """County in JSON, by id, statistics only"""
-    log.debug("entering get_county_by_id_stats() IP=%s" % get_ip());
+    log.debug("entering get_county_by_id_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, s.pop_male / s.pop as pct_male, s.pop_female / s.pop as pct_female, s.pop_sm, " \
         "chr.hs_graduate as chr_hs_grad, chr.college as chr_college, chr.unemployed as chr_unemployed, chr.diabetes_rate as chr_diabetes, " \
@@ -421,7 +423,7 @@ def get_county_by_id_stats(ct_fips):
       "WHERE ct_fips=%s"
     sql_params = (ct_fips,)
     data = getData(con, sql, sql_params)
-    log.debug("leaving get_county_by_id_stats()");
+    log.debug("leaving get_county_by_id_stats()")
     return data
 
 #Request only the statistics of a single county by county id (synthetic)
@@ -430,16 +432,16 @@ def get_county_by_id_stats(ct_fips):
 @cache.memoize(timeout=300) # cache this view for 5 minutes
 def get_synth_county_by_id_stats(ct_fips):
     """County in JSON, by id, statistics only (synthetic)"""
-    log.debug("entering get_synth_county_by_id_stats() IP=%s" % get_ip());
+    log.debug("entering get_synth_county_by_id_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.sq_mi, s.pop, CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, s.pop_sm, " \
-        "f_diabetes.rate as pct_diabetes " \
-      "FROM synth_ma.synth_county_stats s " \
-      "JOIN synth_ma.synth_county_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.countyfp = s.ct_fips " \
-      "WHERE ct_fips=%s"
+        "d.rate as pct_diabetes " \
+      "FROM synth_ma.synth_county_pop_stats s " \
+      "JOIN synth_ma.synth_county_disease_stats d ON d.ct_fips = s.ct_fips " \
+      "WHERE s.ct_fips = %s AND d.disease_name = 'diabetes'"
     sql_params = (ct_fips,)
     data = getData(con, sql, sql_params)
-    log.debug("leaving get_synth_county_by_id_stats()");
+    log.debug("leaving get_synth_county_by_id_stats()")
     return data
 
 #
@@ -451,7 +453,7 @@ def get_synth_county_by_id_stats(ct_fips):
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_cousub_all():
     """Cousubs in GeoJSON"""
-    log.debug("entering get_cousub_all() IP=%s" % get_ip());
+    log.debug("entering get_cousub_all() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.cs_fips, s.cs_name, s.sq_mi, s.pop, s.pop_sm, " \
         "CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, " \
@@ -462,7 +464,7 @@ def get_cousub_all():
 	"JOIN tiger_cb14_500k.cousub g ON g.statefp = '25' AND g.countyfp = s.ct_fips AND g.cousubfp = s.cs_fips AND s.cs_fips != '00000' " \
 	"JOIN synth_ma.ma_opioid2 op ON op.cousubfp = s.cs_fips AND s.cs_fips != '00000' AND year = '2015'"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_cousub_all()");
+    log.debug("leaving get_cousub_all()")
     return data
 
 #Request geojson of all cousubs (synthetic)
@@ -471,19 +473,18 @@ def get_cousub_all():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_synth_cousub_all():
     """Cousubs in GeoJSON (synthetic)"""
-    log.debug("entering get_synth_cousub_all() IP=%s" % get_ip());
+    log.debug("entering get_synth_cousub_all() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.cs_fips, s.cs_name, s.sq_mi, s.pop, s.pop_sm, " \
         "CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, " \
         "CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, " \
-        "f_diabetes.rate as pct_diabetes, " \
-        "ST_AsGeoJSON(g.the_geom) AS geometry " \
-        "FROM synth_ma.synth_cousub_stats s " \
-        "JOIN tiger.cousub g  ON g.statefp = '25' AND g.countyfp = s.ct_fips AND g.cousubfp = s.cs_fips " \
-        "JOIN synth_ma.synth_cousub_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.cousubfp = s.cs_fips " \
-      "WHERE s.cs_fips != '00000'"
+        "d.rate as pct_diabetes, " \
+        "ST_AsGeoJSON(s.cs_poly) AS geometry " \
+        "FROM synth_ma.synth_cousub_pop_stats s " \
+        "JOIN synth_ma.synth_cousub_disease_stats d ON d.cs_fips = s.cs_fips " \
+        "WHERE d.disease_name = 'diabetes'"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_synth_cousub_all()");
+    log.debug("leaving get_synth_cousub_all()")
     return data
 
 #Request geojson of only the geometry of all cousubs
@@ -492,13 +493,13 @@ def get_synth_cousub_all():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_cousub_geom():
     """Cousubs in GeoJSON, geometry only"""
-    log.debug("entering get_cousub_geom() IP=%s" % get_ip());
+    log.debug("entering get_cousub_geom() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT countyfp AS ct_fips, cousubfp AS cs_fips, ST_AsGeoJSON(the_geom) AS geometry " \
       "FROM tiger_cb14_500k.cousub " \
       "WHERE statefp='25' AND cousubfp != '00000'"
     data = p2g.getData(con, sql)
-    log.debug("leaving get_cousub_geom()");
+    log.debug("leaving get_cousub_geom()")
     return data
 
 #Request only the statistics of all cousubs
@@ -507,7 +508,7 @@ def get_cousub_geom():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_cousub_stats():
     """Cousubs in JSON, statistics only"""
-    log.debug("entering get_cousub_stats() IP=%s" % get_ip());
+    log.debug("entering get_cousub_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.cs_fips, s.cs_name, s.sq_mi, s.pop, s.pop_sm, " \
         "CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, " \
@@ -517,7 +518,7 @@ def get_cousub_stats():
 	"JOIN synth_ma.ma_opioid2 op ON op.cousubfp = s.cs_fips AND s.cs_fips != '00000' AND year = '2015' " \
       "WHERE s.cs_fips != '00000'"
     data = getData(con, sql)
-    log.debug("leaving get_cousub_stats()");
+    log.debug("leaving get_cousub_stats()")
     return data
 
 #Request only the statistics of all cousubs (synthetic)
@@ -526,17 +527,17 @@ def get_cousub_stats():
 @cache.cached(timeout=300) # cache this view for 5 minutes
 def get_synth_cousub_stats():
     """Cousubs in JSON, statistics only (synthetic)"""
-    log.debug("entering get_synth_cousub_stats() IP=%s" % get_ip());
+    log.debug("entering get_synth_cousub_stats() IP=%s" % get_ip())
     con = get_db_con()
     sql = "SELECT s.ct_fips, s.ct_name, s.cs_fips, s.cs_name, s.sq_mi, s.pop, s.pop_sm, " \
         "CASE WHEN s.pop > 0 THEN s.pop_male / s.pop ELSE 0 END AS pct_male, " \
         "CASE WHEN s.pop > 0 THEN s.pop_female / s.pop ELSE 0 END AS pct_female, " \
-        "f_diabetes.rate as pct_diabetes " \
-      "FROM synth_ma.synth_cousub_stats s " \
-      "JOIN synth_ma.synth_cousub_facts f_diabetes ON f_diabetes.diseasefp = '" + str(getDiseaseID("diabetes")) + "' AND f_diabetes.cousubfp = s.cs_fips " \
-      "WHERE s.cs_fips != '00000'"
+        "d.rate as pct_diabetes " \
+      "FROM synth_ma.synth_cousub_pop_stats s " \
+      "JOIN synth_ma.synth_cousub_disease_stats d ON d.cs_fips = s.cs_fips " \
+      "WHERE d.disease_name = 'diabetes'"
     data = getData(con, sql)
-    log.debug("leaving get_synth_cousub_stats()");
+    log.debug("leaving get_synth_cousub_stats()")
     return data
 
 #Block level, with filtering
@@ -547,9 +548,11 @@ def get_block_window():
     """Blocks in GeoJSON, by window 
     Example: /htc/api/v1/block_window?minx=-71.26&maxx=-71.22&miny=42.49&maxy=42.51
     """
-    log.debug("entering get_block_window() IP=%s" % get_ip());
-    minx = request.args.get('minx'); maxx = request.args.get('maxx')
-    miny = request.args.get('miny'); maxy = request.args.get('maxy')
+    log.debug("entering get_block_window() IP=%s" % get_ip())
+    minx = request.args.get('minx')
+    maxx = request.args.get('maxx')
+    miny = request.args.get('miny')
+    maxy = request.args.get('maxy')
     if not (minx and maxx and miny and maxy):
         abort(404)
     con = get_db_con()
@@ -559,7 +562,7 @@ def get_block_window():
       "WHERE s.blk_poly && ST_SetSRID(ST_MakeBox2D(ST_Point(%s,%s),  ST_Point(%s,%s)), 4269) AND s.pop > 0"
     sql_params = (minx, miny, maxx, maxy)
     data = p2g.getData(con, sql, sql_params)
-    log.debug("leaving get_block_window()");
+    log.debug("leaving get_block_window()")
     return data
 
 ##TODO
@@ -570,7 +573,7 @@ def get_block_window():
 # this view should not be cached
 def get_synth_ccda_by_id(patient_uuid):
     """Synthetic Patient in C-CDA, by id"""
-    log.debug("entering get_synth_ccda_by_id() IP=%s" % get_ip());
+    log.debug("entering get_synth_ccda_by_id() IP=%s" % get_ip())
     return send_from_directory('/ccda', patient_uuid + '.xml')
 
 


### PR DESCRIPTION
Refactored the existing routes that serve synthetic statistics to query
using the new stats schema. In most cases this was either a change of
the table name being used (switched to using views instead) or a
simplification since fewer joins are now needed to obtain the same data
from the views.

I added one extra route to the synth API to server a list of disease
names that we track statistics for. See .. synth/diseases/list.

As a side note I also removed semicolons after the log.debug()
statements. These semicolons do not affect the execution of the code
(python just ignores them) but they are not syntactically correct. Must
have been added by a Java developer ;)

The API passes all tests in test_rest.sh and the routes return the same
data as previously expected.
