### PR TITLE
Fixed ccda links

### DIFF
--- a/site/assets/scripts/patients.js
+++ b/site/assets/scripts/patients.js
@@ -214,7 +214,7 @@ function getPatientDownloadUrl({id,revIncludeTables = ['*'], count = 20}, format
 }
 
 function getPatientDownloadCcda({id=0}) {
-  return BASE_URL_CCDA + id.substring(0, 2) + "/" + id.substring(2, 5) + "/" + id + ".xml";
+  return BASE_URL_CCDA + id.substring(0, 2) + "/" + id.substring(0, 3) + "/" + id + ".xml";
 }
 
 export function loadPaginationURL(url = '') {


### PR DESCRIPTION
The format is actually id[0:2]/id[0:3]/id.xml, not id[0:2]/id[2:5]/id.xml.