### PR TITLE
Site updates - API and Download pages

### DIFF
--- a/site/about.html
+++ b/site/about.html
@@ -64,11 +64,11 @@
 
             </div>
             <div class="col-md-8 col-md-offset-1">
-              <h1 id="team">About Synthea</h1>
+              <h1 id="team">About Synthea<sup>TM</sup></h1>
 
-              <h2>Synthea - Synthetic Patient Population Simulator</h2>
-              <p><a href="https://github.com/synthetichealth/synthea">Synthea</a> is a Synthetic Patient Population Simulator that is used to generate the synthetic patients within SyntheticMass. Synthea outputs synthetic, realistic (but not real) patient data and associated health records in a variety of formats. Read our <a href="https://github.com/synthetichealth/synthea/wiki">wiki</a> for more information.</p>
-      			  <p>Currently, Synthea features:</p>
+              <h2>Synthea<sup>TM</sup> - Synthetic Patient Population Simulator</h2>
+              <p><a href="https://github.com/synthetichealth/synthea">Synthea<sup>TM</sup></a> is a Synthetic Patient Population Simulator that is used to generate the synthetic patients within SyntheticMass. Synthea outputs synthetic, realistic (but not real) patient data and associated health records in a variety of formats. Read our <a href="https://github.com/synthetichealth/synthea/wiki">wiki</a> for more information.</p>
+              <p>Currently, Synthea<sup>TM</sup> features:</p>
       			  <ul>
       			  	<li>Birth to Death Lifecycle</li>
       			  	<li>Configuration-based statistics and demographics (defaults with Massachusetts Census data)</li>
@@ -86,7 +86,7 @@
       				  </ul>
       				  <li>Rendering Rules and Disease Modules with Graphviz</li>
       			</ul>
-            <p><strong>To contribute</strong>, please visit Synthea on <a href="https://github.com/synthetichealth/synthea">Github</a></p>
+                <p><strong>To contribute</strong>, please visit Synthea<sup>TM</sup> on <a href="https://github.com/synthetichealth/synthea">Github</a></p>
             </div>
           </div>
         </section>
@@ -126,7 +126,7 @@
               <a href="http://www.mitre.org"><img src="<%= require('./assets/img/mitre_bdfd.jpg') %>" alt="MITRE image" class="side_img"/></a>
             </div>
             <div class="col-md-8 col-md-offset-1">
-              <h1 id="team">About the team behind SyntheticMass, Synthea and the Standard Health Record Collaborative</h1>
+                <h1 id="team">About the team behind SyntheticMass, Synthea<sup>TM</sup> and the Standard Health Record Collaborative</h1>
 
               <h2>The MITRE Corporation</h2>
               <p><a href="http://www.mitre.org">The MITRE Corporation</a>  is a not-for-profit company working in the public interest, operating multiple federally funded research and development centers (FFRDCs). FFRDCs are unique organizations that assist the United States government with scientific research and analysis, development and acquisition, and systems engineering and integration. MITRE does not have commercial interests and cannot compete for anything except the right to operate FFRDCs. This lack of commercial conflicts of interest forms the basis for MITRE’s objectivity and subsequent ability to acquire sensitive and proprietary information from the government and industry to inform critical initiatives.

--- a/site/api.html
+++ b/site/api.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,300' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Fjalla+One' rel='stylesheet' type='text/css'>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+  <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
+</head>
+
+<body id="api_page">
+  <%= require('html!./includes/nav.html') %>
+    <div class="container page-container" id="api">
+      <div class="row">
+        <div class="colmd4 collg3">
+
+        </div>
+      </div>
+      <div class="col-md-12">
+        <section>
+          <div class="row">
+            <div class="col-md-3">
+              <a href="http://syntheticmass.mitre.org"><img src="<%= require('./assets/img/synthmass_map.jpg') %>" alt="Background image"  class="side_img"/></a>
+            </div>
+            <div class="col-md-8 col-md-offset-1">
+              <h1 class="page-title">HL7 FHIR API</h1>
+
+              <h2>Overview</h2>
+              <p>
+                SyntheticMass exposes all synthetic medical record data using an HL7 FHIR (Fast Healthcare Interoperability Resources) v.1.8.0 compatible server. 
+                FHIR is a standard for exchanging healthcare data electronically and takes a modern, web-based approach to API design.
+                For information about how to use FHIR, please visit the <a href="http://hl7.org/fhir/2017Jan/index.html">HL7 FHIR v.1.8.0 Documentation</a>.
+                SyntheticMass uses the open source <a href="https://github.com/synthetichealth/gofhir">GoFHIR</a> FHIR server.
+              </p>
+
+              <div class="fhir-endpoint">
+                SyntheticMass FHIR Endpoint: <a href="https://syntheticmass.mitre.org/fhir/">https://syntheticmass.mitre.org/fhir/</a>
+              </div>
+
+              <h2>Examples</h2>
+              <p>
+                 The below examples demonstrate types of queries that can be executed against the SyntheticMass FHIR server using your browser.  
+                 This is not an exhaustive list of the query capabilities of FHIR or the GoFHIR server implementation.
+                 Please review the <a href="http://hl7.org/fhir/2017Jan/index.html">HL7 FHIR v.1.8.0 Documentation</a> for more information.
+              </p>
+
+              <p>
+              Simple Examples:
+              </p>
+
+              <ul>
+                <li><a href="/fhir/Patient?_count=100">All patients, paginated at 100 records</a></li>
+                <li><a href="/fhir/Patient/58b3663e3425def0f0f6a229">Basic information about a single patient</a></li>
+                <li><a href="/fhir/Patient/58b3663e3425def0f0f6a229/$everything">All medical record data related to a patient</a></li>
+              </ul>
+
+              <p>
+              Search Examples:
+              </p>
+
+              <ul>
+                <li><a href="/fhir/Patient?birthdate=gt1947-03-26&birthdate=lte1999-03-26&_count=100">Patients between the ages of 18 and 70</a></li>
+                <li><a href="/fhir/Patient?_has:Condition:subject:code=444814009,75498004,36971009,40055000">Patients with sinusitus</a></li>
+                <li><a href="/fhir/Observation?code=http://loinc.org|19926-5&patient=58b3663e3425def0f0f696a9">Peak flow meter results for a patient</a></li>
+                <li><a href="/fhir/Patient?_has:Procedure:patient:code=112790001 ">Patients that have had a nasal endoscopy procedure</a></li>
+              </ul>
+
+            </div>
+          </div>
+        </section>
+      </div>
+
+    </div>
+    <%= require('html!./includes/footer.html') %>
+      <script>
+        $(document).ready(function() {
+          $("#api_nav a").click(function() {
+            var id = $(this).attr('href');
+            $('html, body').animate({
+              scrollTop: $(id).offset().top - 60
+            }, 1000);
+          });
+        });
+      </script>
+</body>
+
+</html>

--- a/site/api.html
+++ b/site/api.html
@@ -51,25 +51,42 @@
                  Please review the <a href="http://hl7.org/fhir/2017Jan/index.html">HL7 FHIR v.1.8.0 Documentation</a> for more information.
               </p>
 
-              <p>
-              Simple Examples:
-              </p>
+              <h3>Basic Examples</h3>
 
               <ul>
-                <li><a href="/fhir/Patient?_count=100">All patients, paginated at 100 records</a></li>
-                <li><a href="/fhir/Patient/58b3663e3425def0f0f6a229">Basic information about a single patient</a></li>
-                <li><a href="/fhir/Patient/58b3663e3425def0f0f6a229/$everything">All medical record data related to a patient</a></li>
+                <li>
+                  <div>All patients, paginated at 100 records:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient?_count=100">https://syntheticmass.mitre.org/fhir/Patient?_count=100</a>
+                </li>
+                <li>
+                  <div>Basic information about a single patient:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient/58b3663e3425def0f0f6a229">https://syntheticmass.mitre.org/fhir/Patient/58b3663e3425def0f0f6a229</a>
+                </li>
+                <li>
+                  <div>All medical record data related to a patient:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient/58b3663e3425def0f0f6a229/$everything">https://syntheticmass.mitre.org/fhir/Patient/58b3663e3425def0f0f6a229/$everything</a>
+                </li>
               </ul>
 
-              <p>
-              Search Examples:
-              </p>
+              <h3>Search Examples</h3>
 
               <ul>
-                <li><a href="/fhir/Patient?birthdate=gt1947-03-26&birthdate=lte1999-03-26&_count=100">Patients between the ages of 18 and 70</a></li>
-                <li><a href="/fhir/Patient?_has:Condition:subject:code=444814009,75498004,36971009,40055000">Patients with sinusitus</a></li>
-                <li><a href="/fhir/Observation?code=http://loinc.org|19926-5&patient=58b3663e3425def0f0f696a9">Peak flow meter results for a patient</a></li>
-                <li><a href="/fhir/Patient?_has:Procedure:patient:code=112790001 ">Patients that have had a nasal endoscopy procedure</a></li>
+                <li>
+                  <div>Patients between the ages of 18 and 70:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient?birthdate=gt1947-03-26&birthdate=lte1999-03-26&_count=100">https://syntheticmass.mitre.org/fhir/Patient?birthdate=gt1947-03-26&birthdate=lte1999-03-26&_count=100</a>
+                </li>
+                <li>
+                  <div>Patients with sinusitus:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient?_has:Condition:subject:code=444814009,75498004,36971009,40055000">https://syntheticmass.mitre.org/fhir/Patient?_has:Condition:subject:code=444814009,75498004,36971009,40055000</a>
+                </li>
+                <li>
+                  <div>Peak flow meter results for a patient:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Observation?code=http://loinc.org|19926-5&patient=58b3663e3425def0f0f696a9">https://syntheticmass.mitre.org/fhir/Observation?code=http://loinc.org|19926-5&patient=58b3663e3425def0f0f696a9</a>
+                </li>
+                <li>
+                  <div>Patients that have had a nasal endoscopy procedure:</div>
+                  <a href="https://syntheticmass.mitre.org/fhir/Patient?_has:Procedure:patient:code=112790001">https://syntheticmass.mitre.org/fhir/Patient?_has:Procedure:patient:code=112790001</a>
+                </li>
               </ul>
 
             </div>

--- a/site/assets/scripts/ga.js
+++ b/site/assets/scripts/ga.js
@@ -5,3 +5,17 @@
 
   ga('create', 'UA-84987099-1', 'auto');
   ga('send', 'pageview');
+
+/**
+ *   * Function that tracks a click on an outbound link in Analytics.
+ *   * This function takes a valid URL string as an argument, and uses that URL string
+ *   * as the event label. Setting the transport method to 'beacon' lets the hit be sent
+ *   * using 'navigator.sendBeacon' in browser that support it.
+ **/
+
+window.trackOutboundLink = function(url) {
+  ga('send', 'event', 'outbound', 'click', url, {
+    'transport': 'beacon',
+    'hitCallback': function(){document.location = url;}
+  });
+}

--- a/site/assets/scripts/ga_disabled.js
+++ b/site/assets/scripts/ga_disabled.js
@@ -1,0 +1,8 @@
+/** 
+ * This function must be defined, even if we are in staging or development mode
+**/
+
+window.trackOutboundLink = function(url) {
+  console.log('Tracking: ' + url);
+  setTimeout(function(){document.location=url},500); // Mimic production callback
+}

--- a/site/assets/styles/app.scss
+++ b/site/assets/styles/app.scss
@@ -66,8 +66,8 @@ span.subtitle {font-weight:300}
   h1.page-title {padding-top:0}
   img.logo {padding:0 0 12px 20px;float:right}
   ul.nav-fixed {position:fixed}
-
 }
+
 #feedback{
   padding-top:$header-top-height;
   section {margin-bottom:4em;}
@@ -76,8 +76,28 @@ span.subtitle {font-weight:300}
   ul.nav-fixed {position:fixed}
   footer{position: fixed;
   bottom: 0;}
-
 }
+
+#api{
+  padding-top:$header-top-height*2;
+  section {margin-bottom:4em;}
+  h1 {padding-top:10px;}
+  h1.page-title {padding-top:0}
+  img.logo {padding:0 0 12px 20px;float:right}
+  ul.nav-fixed {position:fixed}
+  a {font-weight:bold;}
+  .fhir-endpoint {font-size: 1.1em; font-weight: bold;}
+}
+
+#download{
+  padding-top:$header-top-height*2;
+  section {margin-bottom:4em;}
+  h1 {padding-top:10px;}
+  h1.page-title {padding-top:0}
+  img.logo {padding:0 0 12px 20px;float:right}
+  ul.nav-fixed {position:fixed}
+}
+
 .side_img{padding-top:30px;
   width:200px;}
 
@@ -88,6 +108,8 @@ span.subtitle {font-weight:300}
 #about_page #nav_about {background-color:#18446e}
 #feedback_page #nav_feedback {background-color:#18446e}
 #dashboard_page #nav_dash {background-color:#18446e}
+#api_page #nav_api {background-color:#18446e}
+#download_page #nav_download {background-color:#18446e}
 
 section.footer :target {background-color:#fe4}
 

--- a/site/assets/styles/app.scss
+++ b/site/assets/styles/app.scss
@@ -85,8 +85,9 @@ span.subtitle {font-weight:300}
   h1.page-title {padding-top:0}
   img.logo {padding:0 0 12px 20px;float:right}
   ul.nav-fixed {position:fixed}
-  a {font-weight:bold;}
   .fhir-endpoint {font-size: 1.1em; font-weight: bold;}
+  ul {padding: 0}
+  li {padding: 0 0 10px; list-style-type: none; a {font-size: .9em}}
 }
 
 #download{

--- a/site/download.html
+++ b/site/download.html
@@ -54,17 +54,25 @@
                  Sample files containing 1,000 patient records in multiple formats are available below:
                  <ul>
                    <li><a 
-                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_FHIR.tar.gz'); return false;" 
-                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_FHIR.tar.gz">1K Sample Synthetic Patient Records, FHIR
-                     </a>: 21MB
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_fhir_stu3_nov2017.zip'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_fhir_stu3_nov2017.zip">1K Sample Synthetic Patient Records, FHIR DSTU3
+                     </a>: 20MB
+                   </li>
                    <li><a 
-                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CCDA.tar.gz'); return false;" 
-                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CCDA.tar.gz">1K Sample Synthetic Patient Records, C-CDA
-                     </a>: 7.1MB
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_fhir_dstu2_nov2017.zip'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_fhir_dstu2_nov2017.zip">1K Sample Synthetic Patient Records, FHIR DSTU2
+                     </a>: 13MB
+                   </li>
                    <li><a 
-                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CSV.tar.gz'); return false;" 
-                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CSV.tar.gz">1K Sample Synthetic Patient Records, CSV
-                     </a>: 1.9MB
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_ccda_nov2017.zip'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_ccda_nov2017.zip">1K Sample Synthetic Patient Records, C-CDA
+                     </a>: 12MB
+                   </li>
+                   <li><a 
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_csv_nov2017.zip'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_11_06/synthea_sample_data_csv_nov2017.zip">1K Sample Synthetic Patient Records, CSV
+                     </a>: 3.6MB
+                   </li>
                  </ul>
                </p>
                <p>

--- a/site/download.html
+++ b/site/download.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+  <title>
+    <%= htmlWebpackPlugin.options.title %>
+  </title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link href='//fonts.googleapis.com/css?family=Lato:400,700,300' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Fjalla+One' rel='stylesheet' type='text/css'>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/2.2.2/jquery.min.js"></script>
+  <link rel="icon" type="image/png" href="favicon-32x32.png" sizes="32x32" />
+  <link rel="icon" type="image/png" href="favicon-16x16.png" sizes="16x16" />
+</head>
+
+<body id="download_page">
+  <%= require('html!./includes/nav.html') %>
+    <div class="container page-container" id="api">
+      <div class="row">
+        <div class="colmd4 collg3">
+
+        </div>
+      </div>
+      <div class="col-md-12">
+        <section>
+          <div class="row">
+            <div class="col-md-3">
+              <a href="http://syntheticmass.mitre.org"><img src="<%= require('./assets/img/synthmass_map.jpg') %>" alt="Background image"  class="side_img"/></a>
+            </div>
+            <div class="col-md-8 col-md-offset-1">
+              <h1 class="page-title">Download</h1>
+
+              <p>
+                 The SyntheticMass data set is available for download in bulk as gzip archives.  Each archive contains one million synthetic patient medical records,
+                 encoded in HL7 FHIR, C-CDA and CSV.  Please consider <a href="/feedback.html">reaching out</a> and letting us know how you are using this data set so we can improve it in the future.
+              </p>
+
+               <ul>
+                 <li><a href="/downloads/2017_05_24/synthea_1m_fhir_3_0_May_24.tar.gz">SyntheticMass Data, Version 2 (24 May, 2017)</a>: 21GB. FHIR 3.0.1, CSV, C-CDA</li>
+                 <li><a href="/downloads/2017_02_27/synthea_2017_02_27.tar.gz">SyntheticMass Data, Version 1 (27 Feb, 2017)</a>: 28GB. FHIR 1.8.0, CSV, C-CDA</li>
+               </ul>
+
+               <p>
+                 Sample files containing 1,000 patient records in multiple formats are available below:
+                 <ul>
+                   <li><a href="/downloads/2017_04_20/synthea_1k_FHIR.tar.gz">1K Sample Synthetic Patient Records, FHIR</a>: 21MB
+                   <li><a href="/downloads/2017_04_20/synthea_1k_CCDA.tar.gz">1K Sample Synthetic Patient Records, C-CDA</a>: 7.1MB
+                   <li><a href="/downloads/2017_04_20/synthea_1k_CSV.tar.gz">1K Sample Synthetic Patient Records, CSV</a>: 1.9MB
+                 </ul>
+               </p>
+               <p>
+                 SyntheticMass Data is also available through a rich public data query API using the HL7 FHIR v.1.8.0 standard.  
+                 More information is available on the <a href="api.html">FHIR API</a> page.
+               </p>
+            </div>
+          </div>
+        </section>
+      </div>
+
+    </div>
+    <%= require('html!./includes/footer.html') %>
+      <script>
+        $(document).ready(function() {
+          $("#download_nav a").click(function() {
+            var id = $(this).attr('href');
+            $('html, body').animate({
+              scrollTop: $(id).offset().top - 60
+            }, 1000);
+          });
+        });
+      </script>
+</body>
+
+</html>

--- a/site/download.html
+++ b/site/download.html
@@ -38,16 +38,33 @@
               </p>
 
                <ul>
-                 <li><a href="/downloads/2017_05_24/synthea_1m_fhir_3_0_May_24.tar.gz">SyntheticMass Data, Version 2 (24 May, 2017)</a>: 21GB. FHIR 3.0.1, CSV, C-CDA</li>
-                 <li><a href="/downloads/2017_02_27/synthea_2017_02_27.tar.gz">SyntheticMass Data, Version 1 (27 Feb, 2017)</a>: 28GB. FHIR 1.8.0, CSV, C-CDA</li>
+                 <li><a 
+                     onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_05_24/synthea_1m_fhir_3_0_May_24.tar.gz'); return false;" 
+                     href="https://syntheticmass.mitre.org/downloads/2017_05_24/synthea_1m_fhir_3_0_May_24.tar.gz">SyntheticMass Data, Version 2 (24 May, 2017)
+                   </a>: 21GB. FHIR 3.0.1, CSV, C-CDA
+                 </li>
+                 <li><a 
+                     onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_02_27/synthea_2017_02_27.tar.gz'); return false;" 
+                     href="https://syntheticmass.mitre.org/downloads/2017_02_27/synthea_2017_02_27.tar.gz">SyntheticMass Data, Version 1 (27 Feb, 2017)
+                   </a>: 28GB. FHIR 1.8.0, CSV, C-CDA
+                 </li>
                </ul>
 
                <p>
                  Sample files containing 1,000 patient records in multiple formats are available below:
                  <ul>
-                   <li><a href="/downloads/2017_04_20/synthea_1k_FHIR.tar.gz">1K Sample Synthetic Patient Records, FHIR</a>: 21MB
-                   <li><a href="/downloads/2017_04_20/synthea_1k_CCDA.tar.gz">1K Sample Synthetic Patient Records, C-CDA</a>: 7.1MB
-                   <li><a href="/downloads/2017_04_20/synthea_1k_CSV.tar.gz">1K Sample Synthetic Patient Records, CSV</a>: 1.9MB
+                   <li><a 
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_FHIR.tar.gz'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_FHIR.tar.gz">1K Sample Synthetic Patient Records, FHIR
+                     </a>: 21MB
+                   <li><a 
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CCDA.tar.gz'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CCDA.tar.gz">1K Sample Synthetic Patient Records, C-CDA
+                     </a>: 7.1MB
+                   <li><a 
+                       onclick="trackOutboundLink('https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CSV.tar.gz'); return false;" 
+                       href="https://syntheticmass.mitre.org/downloads/2017_04_20/synthea_1k_CSV.tar.gz">1K Sample Synthetic Patient Records, CSV
+                     </a>: 1.9MB
                  </ul>
                </p>
                <p>

--- a/site/includes/footer.html
+++ b/site/includes/footer.html
@@ -2,6 +2,6 @@
     <p>
       <a href="http://www.mitre.org"><img src="../assets/img/mitre logo_black.png" alt="MITRE image" class="logo" /></a>
       <a href="https://github.com/synthetichealth/syntheticmass"><img src="../assets/img/GitHub-Mark-64px.png" alt="Github page" class="logo" /></a>
-      Copyright &copy; 2016, The MITRE Corporation. All rights reserved.</p>
+      Copyright &copy; 2017, The MITRE Corporation. All rights reserved.</p>
     <p>Approved for Public Release; Distribution Unlimited. Case Number 16-2027</p>
 </footer>

--- a/site/includes/nav.html
+++ b/site/includes/nav.html
@@ -12,6 +12,12 @@
                   <a href="/dashboard/index.html" id="nav_dash">SyntheticMass Dashboard</a>
                 </li>
                 <li>
+                    <a href="download.html" id="nav_download">Download</a>
+                </li>
+                <li>
+                    <a href="api.html" id="nav_api">FHIR API</a>
+                </li>
+                <li>
                     <a href="about.html" id="nav_about">About This Project</a>
                 </li>
                 <li>

--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -42,6 +42,18 @@ var plugins = [
       excludeChunks : ['bundle',analytics]
     }),
     new HtmlWebpackPlugin({
+      template:'./api.html',
+      filename:'api.html',
+      title: 'Synthetic Mass FHIR API',
+      excludeChunks : ['bundle',analytics]
+    }),
+    new HtmlWebpackPlugin({
+      template:'./download.html',
+      filename:'download.html',
+      title: 'Synthetic Mass Download',
+      excludeChunks : ['bundle',analytics]
+    }),
+    new HtmlWebpackPlugin({
       template:'./index.html',
       filename:'index.html',
       title: 'Synthetic Mass',

--- a/site/webpack.config.js
+++ b/site/webpack.config.js
@@ -16,7 +16,7 @@ console.log(__dirname);
 console.log(dir_js);
 
 var PATHS = {images:'/assets/img'};
-var analytics = (production) ? "" : "ga";
+var analytics = (production) ? "ga_disabled" : "ga";
 var plugins = [
     new HtmlWebpackPlugin({
       template: 'dashboard.html',
@@ -137,6 +137,7 @@ module.exports = {
     'fa' : 'font-awesome-loader',
     'bs' : 'bootstrap-loader',
     'ga' : path.resolve(dir_js,'ga.js'),
+    'ga_disabled' : path.resolve(dir_js,'ga_disabled.js'),
     'bundle' : path.resolve(dir_js,'app.js')
   },
   output: {


### PR DESCRIPTION
Need to update download links to point to newer samples that Jay just put together, at the very least.

Open to any recommendations for changes in language, examples, etc.

Also, I saw we have multiple full-population downloads in our downloads folder.  I referenced them as 'Version 1' and 'Version 2', as I thought it might be useful to have a version concept for our data.  But I can just reference the most recent version as well.